### PR TITLE
Upgrade to .NET 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.3.0 (2025-09-08)
+## Changes
+- Add support for .NET 9.0
+- Remove support for .NET 6.0 and .NET 8.0
+- Upgrade Microsoft.EntityFrameworkCore.Sqlite packages to latest
+
 # 7.2.4 (2024-06-17)
 ## Misc
 - Upgrade Microsoft.EntityFrameworkCore.Sqlite packages to latest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There are two packages offered within this repo:
 
 ## Requirements
 
-Using these packages requires the project to be on .NET 6.0 or newer. These packages should only be used with projects using EntityFramework version 6.x.x or higher on .NET 6.0, version 7.x.x on .NET 7.0, or version 8.x.x on .NET 8.0.
+Using these packages requires the project to be on .NET 8.0 or newer. These packages should only be used with projects using EntityFramework version 8.x.x or higher on .NET 8.0, or version 9.x.x on .NET 9.0.
 
 ## Contribute
 

--- a/src/SqliteMemoryDatabaseProvider.AutoMocker/SqliteMemoryDatabaseProvider.AutoMocker.csproj
+++ b/src/SqliteMemoryDatabaseProvider.AutoMocker/SqliteMemoryDatabaseProvider.AutoMocker.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>7.2.4</Version>
+        <Version>7.3.0</Version>
         <Title>SQLite Memory Database Provider AutoMocker</Title>
         <Authors>Owen Krueger</Authors>
         <RootNamespace>SqliteMemoryDatabaseProvider.AutoMocker</RootNamespace>
         <Description>For creating in-memory SQLite databases to be used within unit tests using AutoMocker.</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageProjectUrl>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageTags>Moq;AutoMock;EntityFramework;SQLite;Unit Test;Unit Testing;Database;DbContext</PackageTags>
         <RepositoryUrl>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageReleaseNotes>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider/releases/tag/v7.2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider/releases/tag/v7.3.0</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SqliteMemoryDatabaseProvider/SqliteMemoryDatabaseProvider.csproj
+++ b/src/SqliteMemoryDatabaseProvider/SqliteMemoryDatabaseProvider.csproj
@@ -1,34 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>7.2.4</Version>
+        <Version>7.3.0</Version>
         <Title>SQLite Memory Database Provider</Title>
         <Authors>Owen Krueger</Authors>
         <RootNamespace>SqliteMemoryDatabaseProvider</RootNamespace>
         <Description>For creating in-memory SQLite databases to be used within unit tests.</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageProjectUrl>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageTags>EntityFramework;SQLite;Unit Test;Unit Testing;Database;DbContext</PackageTags>
         <RepositoryUrl>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageReleaseNotes>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider/releases/tag/v7.2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/Owen-Krueger/SqliteMemoryDatabaseProvider/releases/tag/v7.3.0</PackageReleaseNotes>
     </PropertyGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.31" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.20" />
-    </ItemGroup>
-
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/SqliteMemoryDatabaseProvider.UnitTests.csproj
+++ b/tests/SqliteMemoryDatabaseProvider.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -12,15 +12,15 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
- Add support for .NET 9.0
- Remove support for .NET 6.0 and .NET 8.0
- Upgrade Microsoft.EntityFrameworkCore.Sqlite packages to latest